### PR TITLE
Use absolute imports

### DIFF
--- a/irc/example/main.go
+++ b/irc/example/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"./irc"
-	"./irc/irce"
 	"log"
+
+	"github.com/liamzdenek/go-irc/irc"
+	"github.com/liamzdenek/go-irc/irc/irce"
 )
 
 func main() {

--- a/irc/irce/ChannelHandler.go
+++ b/irc/irce/ChannelHandler.go
@@ -1,9 +1,10 @@
 package irce
 
 import (
-	".."
 	"log"
 	"strings"
+
+	"github.com/liamzdenek/go-irc/irc"
 )
 
 type ChannelHandler struct {

--- a/irc/irce/LogHandler.go
+++ b/irc/irce/LogHandler.go
@@ -1,8 +1,9 @@
 package irce
 
 import (
-	".."
 	"log"
+
+	"github.com/liamzdenek/go-irc/irc"
 )
 
 func LogHandler(e irc.Event) {

--- a/main.go
+++ b/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"./irc"
-	"./irc/irce"
 	"fmt"
 	"log"
 	"time"
 	"strings"
+
+	"github.com/liamzdenek/go-irc/irc"
+	"github.com/liamzdenek/go-irc/irc/irce"
 )
 
 func main() {


### PR DESCRIPTION
Relative imports make `go get github.com/liamzdenek/go-irc` complain:

```
can't load package: $GOPATH/src/github.com/liamzdenek/go-irc/irc/irce/ChannelHandler.go:4:2: local import ".." in non-local package
```
