### PR TITLE
Introduce a safe mechanism for adding arbitrary text to an IRC command/&Line{}

### DIFF
--- a/irc/example/main.go
+++ b/irc/example/main.go
@@ -9,24 +9,24 @@ import (
 
 func main() {
 	i := irc.NewIRC("hypeirc:6667")
-	ch := irce.NewChannelHandler(i);
-	
-	log.Printf("Entering main loop\n");
+	ch := irce.NewChannelHandler(i)
+
+	log.Printf("Entering main loop\n")
 	for e := range i.Rx {
 		// prints nice messages to stdout... great for debugging/logging
-		// this line can be put after the PingHandler (given that you're 
+		// this line can be put after the PingHandler (given that you're
 		// continuing when it returns true) and it won't print Pings
-		irce.LogHandler(e);
+		irce.LogHandler(e)
 
 		// handles PING/PONG automatically. You generally want this
 		if i.PingHandler(e) {
 			// prevents other handlers from wasting their time
 			// when this ping has already been handled. we can just abort
 			// early
-			continue;
+			continue
 		}
 
-		ch.Handle(e);
+		ch.Handle(e)
 
 		// Extras TODO:
 		// * ChannelHandler, manages the channels and the users in them.
@@ -39,19 +39,19 @@ func main() {
 		switch l := e.(type) {
 		case *irc.EConnect:
 			i.Tx <- &irc.Line{
-				Command: "NICK",
+				Command:   "NICK",
 				Arguments: []string{"LiamTest"},
 			}
 			i.Tx <- &irc.Line{
-				Command: "USER",
+				Command:   "USER",
 				Arguments: []string{"LiamTest", "8", "*"},
-				Suffix: "Liam Test",
+				Suffix:    "Liam Test",
 			}
 		case *irc.Line:
 			switch l.Command {
 			case "001":
 				i.Tx <- &irc.Line{
-					Command: "JOIN",
+					Command:   "JOIN",
 					Arguments: []string{"#rust-nuts"},
 				}
 			}

--- a/irc/irce/ChannelHandler.go
+++ b/irc/irce/ChannelHandler.go
@@ -48,10 +48,12 @@ func (ch *ChannelHandler) Join(c string) {
 
 	if ch.joinQueue == nil {
 		go func() {
-			ch.irc.Tx <- &irc.Line{
-				Command:   "JOIN",
-				Arguments: []string{c},
-			}
+            line, _ := irc.NewLineBuilder().
+                Command("JOIN").
+                ArgsFromString(c).
+                Consume();
+            ch.irc.Tx <- line;
+
 		}()
 	} else {
 		ch.pushJoinQueue(c)

--- a/irc/irce/ChannelHandler.go
+++ b/irc/irce/ChannelHandler.go
@@ -48,11 +48,11 @@ func (ch *ChannelHandler) Join(c string) {
 
 	if ch.joinQueue == nil {
 		go func() {
-            line, _ := irc.NewLineBuilder().
-                Command("JOIN").
-                ArgsFromString(c).
-                Consume();
-            ch.irc.Tx <- line;
+			line, _ := irc.NewLineBuilder().
+				Command("JOIN").
+				ArgsFromString(c).
+				Consume()
+			ch.irc.Tx <- line
 
 		}()
 	} else {
@@ -68,10 +68,10 @@ func (ch *ChannelHandler) pushJoinQueue(c string) {
 func (ch *ChannelHandler) popJoinQueue(c string) {
 	for i, v := range *ch.joinQueue {
 		if v == c {
-			k := *ch.joinQueue;
-			k = append(k[:i], k[i+1:]...);
-			ch.joinQueue = &k;
-			break;
+			k := *ch.joinQueue
+			k = append(k[:i], k[i+1:]...)
+			ch.joinQueue = &k
+			break
 		}
 	}
 }

--- a/irc/irce/LogHandler.go
+++ b/irc/irce/LogHandler.go
@@ -7,7 +7,7 @@ import (
 )
 
 func LogHandler(e irc.Event) {
-	log.Printf("GOT EVENT: %s\n", e);
+	log.Printf("GOT EVENT: %s\n", e)
 	switch l := e.(type) {
 	case *irc.EConnect:
 		log.Printf("Connected\n")

--- a/main.go
+++ b/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/liamzdenek/go-irc/irc"
 	"github.com/liamzdenek/go-irc/irc/irce"
@@ -74,17 +74,17 @@ func main() {
 			case *irc.Line:
 				switch l.Command {
 				case "JOIN":
-					c := l.Suffix;
+					c := l.Suffix
 					if Conf.Channels[c] != nil {
-						log.Printf("GOT A JOIN IN: %s\n", c);
-						p := strings.Split(l.Prefix, "@");
+						log.Printf("GOT A JOIN IN: %s\n", c)
+						p := strings.Split(l.Prefix, "@")
 						if len(p) > 1 {
-							ident := p[len(p)-1];
-							name_parts := strings.Split(p[0], "!");
-							name := name_parts[0];
+							ident := p[len(p)-1]
+							name_parts := strings.Split(p[0], "!")
+							name := name_parts[0]
 							for _, person := range Conf.Channels[c].Ops {
-								log.Printf("NAME: %s, IDENT: %s PERSON: %s\n", name, ident, person);
-								if(person == ident) {
+								log.Printf("NAME: %s, IDENT: %s PERSON: %s\n", name, ident, person)
+								if person == ident {
 									i.Tx <- &irc.Line{
 										Command:   "MODE",
 										Arguments: []string{c, "+o", name},

--- a/tools.go
+++ b/tools.go
@@ -1,7 +1,7 @@
-package main;
+package main
 
 func Check(e error) {
 	if e != nil {
-		panic(e);
+		panic(e)
 	}
 }


### PR DESCRIPTION
#6

Considerations:
- Preserve reverse-compatibility. I ultimately did not do this, as NewLine() was renamed to NewLineFromRaw(), however, older code should be able to simply use this function in place, and everything should continue to work. This is an acceptable compromise in exchange for clarity, IMO
- Preserve an escape hatch for arbitrary code. Sometimes, validation is a waste, and I would like to opt out sometimes. In its current form, that escape hatch is via a &Line{} literal.
- Selection of the correct pattern. I chose the builder pattern (even though it is a bit wordy for such a simple use case) in exchange for modularity, and brevity of end-user code.
- re prev: Optional sanitization. I would like the end user to be able to explicitly .Sanitize() to clean it up, or neglect it and catch an error instead.
